### PR TITLE
Fix for a couple unitialized value errors.

### DIFF
--- a/pslse/psl_interface/psl_interface.c
+++ b/pslse/psl_interface/psl_interface.c
@@ -171,22 +171,10 @@ static int establish_protocol (struct AFU_EVENT *event)
 void
 psl_event_reset (struct AFU_EVENT *event)
 {
-  event->job_valid = 0;
-  event->clock = 0;
+  memset(event, 0, sizeof(*event));
   event->proto_primary = PROTOCOL_PRIMARY;
   event->proto_secondary = PROTOCOL_SECONDARY;
   event->proto_tertiary = PROTOCOL_TERTIARY;
-  event->mmio_valid = 0;
-  event->response_valid = 0;
-  event->credits = 0;
-  event->cache_state = 0;
-  event->buffer_read = 0;
-  event->buffer_write = 0;
-  event->command_valid = 0;
-  event->aux1_change = 0;
-  event->aux2_change = 0;
-  event->mmio_ack = 0;
-  event->buffer_rdata_valid = 0;
 }
 
 /* Call this once after creation to initialize the AFU_EVENT structure and


### PR DESCRIPTION
As detected by valgrind:

==20067== Conditional jump or move depends on uninitialised value(s)
==20067==    at 0x40905C: psl_signal_afu_model (psl_interface.c:645)
==20067==    by 0x406A63: psl (libcxl.c:865)
==20067==    by 0x50BA9D0: start_thread (pthread_create.c:301)
==20067==    by 0xDC6C6FF: ???
==20067==
==20067== Syscall param socketcall.sendto(msg) points to uninitialised byte(s)
==20067==    at 0x50C1CDC: send (send.c:33)
==20067==    by 0x4091E8: psl_signal_afu_model (psl_interface.c:715)
==20067==    by 0x406A63: psl (libcxl.c:865)
==20067==    by 0x50BA9D0: start_thread (pthread_create.c:301)
==20067==    by 0xDC6C6FF: ???
==20067==  Address 0x586d909 is 25 bytes inside a block of size 944 alloc'd
==20067==    at 0x4C27A2E: malloc (vg_replace_malloc.c:270)
==20067==    by 0x405F10: cxl_afu_open_dev (libcxl.c:902)
==20067==    by 0x4026AF: wqueue_init (wqueue.c:46)
==20067==    by 0x401F52: main (unittest.c:241)
